### PR TITLE
1 add new line to quote bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-secret
+.env

--- a/src/feature.go
+++ b/src/feature.go
@@ -23,8 +23,7 @@ func formatCitation(citation string, author string, date string) string {
 	} else {
 		t, _ = time.Parse("2-1-2006", date)
 	}
-	strings.ReplaceAll(citation, "*", "_")
-	output := fmt.Sprintf(">>> *%s*\n**%s** | *%s*", citation, author, t.Format("02.01.2006"))
+	output := fmt.Sprintf(">>> %s\n**%s** | *%s*", citation, author, t.Format("02.01.2006"))
 	log.Printf("Format citation : %s", output)
 	return output
 }

--- a/src/feature.go
+++ b/src/feature.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"log"
 	"math/rand"
 	"strings"
 	"time"
@@ -23,8 +22,9 @@ func formatCitation(citation string, author string, date string) string {
 	} else {
 		t, _ = time.Parse("2-1-2006", date)
 	}
+	citation = strings.ReplaceAll(citation, "\\n", "\n")
 	output := fmt.Sprintf(">>> %s\n**%s** | *%s*", citation, author, t.Format("02.01.2006"))
-	log.Printf("Format citation : %s", output)
+	//log.Printf("Format citation : %s", output) //DEBUG
 	return output
 }
 


### PR DESCRIPTION
Switch gitiginore variable to ".env" instead of "secret" for keys
Remove the italic format in the quote to allow user to format their quote as they want 
Add support for \n to allow user to have line return 